### PR TITLE
(fix) don't use black highlighting

### DIFF
--- a/lib/swoop/formatter.rb
+++ b/lib/swoop/formatter.rb
@@ -2,7 +2,7 @@ class Swoop::Formatter
 
   def call(severity, datetime, progname, msg)
     if Swoop.colorize?
-      "#{ severity[0].bold.send(severity_color(severity)) } #{ datetime.iso8601.bold.black } #{ (progname || "app").bold }: #{ msg.strip }\n"
+      "#{ severity[0].bold.send(severity_color(severity)) } #{ datetime.iso8601.blue } #{ (progname || "app").bold }: #{ msg.strip }\n"
     else
       "#{ severity[0] } #{ datetime.iso8601 } #{ progname || "rails" }: #{ msg.strip }\n"
     end
@@ -10,7 +10,7 @@ class Swoop::Formatter
 
   def severity_color(severity)
     case severity
-    when "DEBUG" then :black
+    when "DEBUG" then :blue
     when "INFO" then :blue
     when "WARN" then :yellow
     when "ERROR" then :red

--- a/lib/swoop/formatters/colored_key_value.rb
+++ b/lib/swoop/formatters/colored_key_value.rb
@@ -29,7 +29,7 @@ module Swoop
         elsif value.is_a?(Symbol)
           value = "#{ value }".blue.bold
         elsif value.is_a?(Hash)
-          value = value.to_json.black.bold
+          value = value.to_json
         end
       end
 


### PR DESCRIPTION
On dark terminal themes it's hard to see, so we're making it harder to see
 important information

 Instead generally use whatever the default main colour is.

 We could alternatively use green, which is what is used for strings. I'm agnostic.