### PR TITLE
(chore) Remove Geminabox

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,15 @@
 # Swoop
 Ruby gem for dxw flavored rails logging extending lograge
 
+## Installation
+
+Add the following to your gemfile
+
+```
+gem 'swoop', git: 'https://github.com/dxw/swoop.git', tag: 'v0.0.7'
+```
+
+
 ## Configuratuin
 
 ### Colorise logs
@@ -19,3 +28,7 @@ I 2015-02-17T16:05:04+00:00 my awesome app: method=GET path=/v1/users/1 format=j
 ```
 gem "colored", "~> 0.0.5"
 ```
+
+## Releasing a new version
+
+Run `$ bundle exec rake release`. This will attach a version number tag of the form `v0.0.7` to HEAD and push it to GitHub.

--- a/Rakefile
+++ b/Rakefile
@@ -1,2 +1,8 @@
-require 'geminabox-release'
-GeminaboxRelease.patch(host: 'https://gems.dxw.net')
+desc "Release HEAD as version v#{Swoop::VERSION} (value read from lib/swoop/version.rb)"
+task :release do
+  version = Swoop::VERSION
+  puts "Tagging version #{version} and pushing to GitHub..."
+  system("git tag v#{version}")
+  system("git push --tags")
+end
+

--- a/swoop.gemspec
+++ b/swoop.gemspec
@@ -19,7 +19,4 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "bundler", "~> 1.6"
   spec.add_development_dependency "rake", "~> 10.0"
-  spec.add_development_dependency 'geminabox-release', '~> 0.2', '>= 0.2.0'
-
-  spec.metadata['allowed_push_host'] = 'https://gems.dxw.net'
 end


### PR DESCRIPTION
Users of this gem should fetch it from GitHub rather than `gems.dxw.net`. It is public code so there is no need for a private gem repo.