### PR TITLE
Update rake dependency to v12.3.3

### DIFF
--- a/lib/swoop/version.rb
+++ b/lib/swoop/version.rb
@@ -1,3 +1,3 @@
 module Swoop
-  VERSION = "0.0.7"
+  VERSION = "0.0.8"
 end

--- a/swoop.gemspec
+++ b/swoop.gemspec
@@ -18,5 +18,5 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_development_dependency "bundler", "~> 1.6"
-  spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "rake", ">= 12.3.3"
 end


### PR DESCRIPTION
Fixes command injection vulnerability [CVE-2020-8130](https://nvd.nist.gov/vuln/detail/CVE-2020-8130)